### PR TITLE
Add GoRails to screencast section

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Ruby |[Eloquent Ruby](http://eloquentruby.com/)|Medium|Book
 # Screencasts
 
 1. [RailsCasts: Ruby on Rails Screencasts](http://railscasts.com/)
+2. [GoRails](https://gorails.com)
 
 # Slides
 


### PR DESCRIPTION
I run a site with Rails screencasts called [GoRails](https://gorails.com). Figured I'd add it to the list! :)